### PR TITLE
osinfo-db: Remove qxldod info from w8, w8.1, and w10

### DIFF
--- a/virtio-win-pre-installable-drivers-win-10.xml
+++ b/virtio-win-pre-installable-drivers-win-10.xml
@@ -50,11 +50,6 @@
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
 
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
-
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>
       <file>vioinput.inf</file>
@@ -117,11 +112,6 @@
 
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
-
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
 
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>

--- a/virtio-win-pre-installable-drivers-win-8.1.xml
+++ b/virtio-win-pre-installable-drivers-win-8.1.xml
@@ -50,11 +50,6 @@
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
 
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
-
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>
       <file>vioinput.inf</file>
@@ -116,11 +111,6 @@
 
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
-
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
 
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>

--- a/virtio-win-pre-installable-drivers-win-8.xml
+++ b/virtio-win-pre-installable-drivers-win-8.xml
@@ -52,11 +52,6 @@
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
 
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
-
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>
       <file>vioinput.inf</file>
@@ -118,11 +113,6 @@
 
       <file>qemupciserial.cat</file>
       <file>qemupciserial.inf</file>
-
-      <file>qxldod.cat</file>
-      <file>qxldod.inf</file>
-      <file>qxldod.sys</file>
-      <device id="http://pcisig.com/pci/1b36/0100"/> 
 
       <file>viohidkmdf.sys</file>
       <file>vioinput.cat</file>


### PR DESCRIPTION
Those files are not shipped in the RPM, causing a breakage on apps
trying to load them.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>