### PR TITLE
osinfo-db: w8, w8.1, and w10 now ship virtiofs drivers

### DIFF
--- a/virtio-win-pre-installable-drivers-win-10.xml
+++ b/virtio-win-pre-installable-drivers-win-10.xml
@@ -90,8 +90,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
 
     <driver signed="true" pre-installable="true" location="file:///usr/share/virtio-win/drivers/by-os/amd64/w10/" arch="x86_64">
@@ -158,8 +157,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
   </os>
 </libosinfo>

--- a/virtio-win-pre-installable-drivers-win-8.1.xml
+++ b/virtio-win-pre-installable-drivers-win-8.1.xml
@@ -90,8 +90,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
 
     <driver signed="true" pre-installable="true" location="file:///usr/share/virtio-win/drivers/by-os/amd64/w8.1/" arch="x86_64">
@@ -157,8 +156,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
   </os>
 </libosinfo>

--- a/virtio-win-pre-installable-drivers-win-8.xml
+++ b/virtio-win-pre-installable-drivers-win-8.xml
@@ -92,8 +92,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
 
     <driver signed="true" pre-installable="true" location="file:///usr/share/virtio-win/drivers/by-os/amd64/w8/" arch="x86_64">
@@ -159,8 +158,7 @@
       <file>viofs.cat</file>
       <file>viofs.inf</file>
       <file>viofs.sys</file>
-      <device id="http://pcisig.com/pci/1af4/1009"/>
-      <device id="http://pcisig.com/pci/1af4/1049"/>
+      <device id="http://pcisig.com/pci/1af4/105a"/>
     </driver>
   </os>
 </libosinfo>


### PR DESCRIPTION
viofs, originally used for 9p, now has been repurposed to be used for
virtiofs.

Let's adapt the osinfo-db files to reflect that.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>