### PR TITLE
osinfo: Fix typo in Windows 7 drivers path

### DIFF
--- a/virtio-win-pre-installable-drivers-win-7.xml
+++ b/virtio-win-pre-installable-drivers-win-7.xml
@@ -91,7 +91,7 @@
       <device id="http://pcisig.com/pci/1af4/1042"/> 
     </driver>
 
-    <driver signed="true" pre-installable="true" location="file:///usr/share/virtio-win/driver/by-os/amd64/w7/" arch="x86_64">
+    <driver signed="true" pre-installable="true" location="file:///usr/share/virtio-win/drivers/by-os/amd64/w7/" arch="x86_64">
       <file>WdfCoInstaller01009.dll</file>
 
       <file>balloon.cat</file>


### PR DESCRIPTION
The path should be file:///usr/share/virtio-win/drivers/by-os/amd64/w7/
instead of file:///usr/share/virtio-win/driver/by-os/amd64/w7/.

The difference is in the "drivers" folder (currently named as "driver").

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>