### PR TITLE
use https instead of http

### DIFF
--- a/data/virtio-win.repo
+++ b/data/virtio-win.repo
@@ -3,21 +3,21 @@
 
 [virtio-win-stable]
 name=virtio-win builds roughly matching what was shipped in latest RHEL
-baseurl=http://fedorapeople.org/groups/virt/virtio-win/repo/stable
+baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/stable
 enabled=1
 skip_if_unavailable=1
 gpgcheck=0
 
 [virtio-win-latest]
 name=Latest virtio-win builds
-baseurl=http://fedorapeople.org/groups/virt/virtio-win/repo/latest
+baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/latest
 enabled=0
 skip_if_unavailable=1
 gpgcheck=0
 
 [virtio-win-source]
 name=virtio-win source RPMs
-baseurl=http://fedorapeople.org/groups/virt/virtio-win/repo/srpms
+baseurl=https://fedorapeople.org/groups/virt/virtio-win/repo/srpms
 enabled=0
 skip_if_unavailable=1
 gpgcheck=0


### PR DESCRIPTION
The fedorapeople web server has proper https support and a valid cert. It's probably just an oversight or holdover from long ago that the repo file uses plain http.