### PR TITLE
fix for RHEL-726 virtio-rng driver for Windows should be compiled for…

### DIFF
--- a/util/filemap.py
+++ b/util/filemap.py
@@ -154,8 +154,6 @@ _viorngfiles = [
     'viorng.inf',
     'viorng.pdb',
     'viorng.sys',
-    'viorngci.dll',
-    'viorngci.pdb',
     'viorngum.dll',
     'viorngum.pdb',
 ]


### PR DESCRIPTION
virtio-rng driver for Windows should be compiled for "Universal" platform