### PR TITLE
Refactor bug report template headings, and improve grammar.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,32 +4,38 @@ about: Create a report to help us improve
 title: ''
 labels: Bug
 assignees: vrozenfe
-
 ---
 
-**Describe the bug**
+#### **Describe the bug**
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behaviour:
+#### **To Reproduce**
 
-**Expected behavior**
+Steps to reproduce the behaviour.
+
+#### **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+#### **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
-**Host:**
- - Disto: [e.g. Fedora, Ubuntu, Proxmox]
+#### **Host**
+
+ - Distro: [e.g. Fedora, Ubuntu, Proxmox]
  - Kernel version
  - QEMU version
  - QEMU command line
  - libvirt version
  - libvirt XML file
 
-**Guest:**
+#### **Guest**
+
  - Windows version
  - virtio-win version or commit hash that was used to build it
 
-**Additional context**
+#### **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: Bug
 assignees: vrozenfe
 ---
 
-#### **Describe the bug**
+#### Describe the bug
 
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,19 +10,19 @@ assignees: vrozenfe
 
 A clear and concise description of what the bug is.
 
-#### **To Reproduce**
+#### To reproduce
 
 Steps to reproduce the behaviour.
 
-#### **Expected behavior**
+#### Expected behavior
 
 A clear and concise description of what you expected to happen.
 
-#### **Screenshots**
+#### Screenshots
 
 If applicable, add screenshots to help explain your problem.
 
-#### **Host**
+#### Host
 
  - Distro: [e.g. Fedora, Ubuntu, Proxmox]
  - Kernel version
@@ -31,11 +31,11 @@ If applicable, add screenshots to help explain your problem.
  - libvirt version
  - libvirt XML file
 
-#### **Guest**
+#### Guest
 
  - Windows version
  - virtio-win version or commit hash that was used to build it
 
-#### **Additional context**
+#### Additional context
 
 Add any other context about the problem here.


### PR DESCRIPTION
1. Remediated a misspelling of “distro” as “disto”.

2. Updated bug report template to use consistent heading styles (no colons for all).

3. Made headings semantic, so that they can't render inline, and shall be read by screen readers.