### PR TITLE
Update the RPM URI to refer to GitHub, not RedHat.

### DIFF
--- a/virtio-win.spec
+++ b/virtio-win.spec
@@ -47,7 +47,7 @@ Name: virtio-win
 Version: 0.1.271
 Release: 1
 Group: Applications/System
-URL: http://www.redhat.com/
+URL: https://github.com/virtio-win/virtio-win-pkg-scripts
 BuildArch: noarch
 
 %if %{rhel_defaults}

--- a/virtio-win.spec
+++ b/virtio-win.spec
@@ -47,7 +47,7 @@ Name: virtio-win
 Version: 0.1.271
 Release: 1
 Group: Applications/System
-URL: https://github.com/virtio-win/virtio-win-pkg-scripts
+URL: https://github.com/virtio-win/kvm-guest-drivers-windows/issues
 BuildArch: noarch
 
 %if %{rhel_defaults}


### PR DESCRIPTION
Updates the RPM specification URI to refer to this GitHub repository, rather than RedHat. I don't know whether a “Bug URL” key would also be useful.